### PR TITLE
Changed Browser alerts to ElementUI alerts

### DIFF
--- a/app/javascript/components/dashboard/issues/issue_form.vue
+++ b/app/javascript/components/dashboard/issues/issue_form.vue
@@ -1411,14 +1411,29 @@ export default {
       this.DV_issue.issueFiles = _files;
     },
     deleteIssue() {
-      let confirm = window.confirm(
-        `Are you sure you want to delete this issue?`
-      );
-      if (!confirm) {
-        return;
-      }
-      this.issueDeleted(this.DV_issue);
-      this.cancelIssueSave();
+      this.$confirm(`Are you sure you want to delete ${this.DV_issue.title}?`, ` Confirm Delete`, {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          this.issueDeleted(this.DV_issue).then((value) => {
+            if (value === 'Success') {
+              this.$message({
+                message: `${this.DV_issue.title} was deleted successfully.`,
+                type: "success",
+                showClose: true,
+              });
+            }
+          });
+          this.cancelIssueSave();
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: 'Delete canceled',
+            showClose: true
+          });          
+        });
+             
     },
     deleteFile(file) {
       if (!file) return;
@@ -1981,6 +1996,16 @@ export default {
     },
     "DV_issue.startDate"(value) {
       if (!value) this.DV_issue.dueDate = "";
+    },
+    "DV_issue.dueDate"(value) {
+      if (this.facility.dueDate) {
+        if (moment(value).isAfter(this.facility.dueDate, "day")) {
+          this.$alert(`${this.DV_issue.title} Due Date is past Project Due Date!`, `${this.DV_issue.title} Due Date Warning`, {
+          confirmButtonText: 'Ok',
+          type: 'info'
+        });
+        }
+      }
     },
     "DV_issue.checklists": {
       handler: function(value) {

--- a/app/javascript/components/dashboard/issues/issue_sheets.vue
+++ b/app/javascript/components/dashboard/issues/issue_sheets.vue
@@ -111,9 +111,27 @@
           this.$router.push(`/programs/${this.$route.params.programId}/sheet/projects/${this.$route.params.projectId}/issues/${this.DV_edit_issue.id}`)
       },
       deleteIssue() {
-        let confirm = window.confirm(`Are you sure, you want to delete this issue?`)
-        if (!confirm) {return}
-        this.issueDeleted(this.DV_issue)
+        this.$confirm(`Are you sure you want to delete ${this.DV_issue.text}?`, 'Confirm Delete', {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          this.issueDeleted(this.DV_issue).then((value) => {
+            if (value === 'Success') {
+              this.$message({
+                message: `${this.DV_issue.text} was deleted successfully.`,
+                type: "success",
+                showClose: true,
+              });
+            }
+          });
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: 'Delete canceled',
+            showClose: true
+          });          
+        });
       },
       openSubTask(subTask) {
         let task = this.currentTasks.find(t => t.id == subTask.id)

--- a/app/javascript/components/dashboard/issues/issue_show.vue
+++ b/app/javascript/components/dashboard/issues/issue_show.vue
@@ -160,9 +160,27 @@
         }      
       },
       deleteIssue() {
-        let confirm = window.confirm(`Are you sure, you want to delete this issue?`)
-        if (!confirm) {return}
-        this.issueDeleted(this.DV_issue)
+        this.$confirm(`Are you sure you want to delete ${this.DV_issue.text}?`, 'Confirm Delete', {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          this.issueDeleted(this.DV_issue).then((value) => {
+            if (value === 'Success') {
+              this.$message({
+                message: `${this.DV_issue.text} was deleted successfully.`,
+                type: "success",
+                showClose: true,
+              });
+            }
+          });
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: 'Delete canceled',
+            showClose: true
+          });          
+        });
       },
       openSubTask(subTask) {
         let task = this.currentTasks.find(t => t.id == subTask.id)

--- a/app/javascript/components/dashboard/members_view.vue
+++ b/app/javascript/components/dashboard/members_view.vue
@@ -245,7 +245,11 @@ import 'jspdf-autotable'
           if(this.currentPage > 1) this.currentPage--;
         },
        clear: function(){
-            alert('this button works')
+          this.$alert('this button works',
+            {
+              confirmButtonText: 'OK',
+              type:'info'      
+            });
         // document.getElementsByClassName("searchbox").empty();
         },
        memberSearch() {

--- a/app/javascript/components/dashboard/notes/notes_form.vue
+++ b/app/javascript/components/dashboard/notes/notes_form.vue
@@ -237,9 +237,27 @@
         })
       },
       deleteNote() {
-        var confirm = window.confirm(`Are you sure, you want to delete this note?`)
-        if (!confirm) return;
-        this.noteDeleted({note: this.DV_note, facilityId: this.facility.id, projectId: this.currentProject.id, cb: () => this.cancelNoteSave() })
+        this.$confirm(`Are you sure you want to delete this note?`, 'Confirm Delete', {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          this.noteDeleted({note: this.DV_note, facilityId: this.facility.id, projectId: this.currentProject.id, cb: () => this.cancelNoteSave() }).then((value) => {
+            if (value === 'Success') {
+              this.$message({
+                message: `Note was deleted successfully.`,
+                type: "success",
+                showClose: true,
+              });
+            }
+          });
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: 'Delete canceled',
+            showClose: true
+          });          
+        }); 
       },
       cancelNoteSave() {
         this.$emit('close-note-input')

--- a/app/javascript/components/dashboard/notes/notes_sheets.vue
+++ b/app/javascript/components/dashboard/notes/notes_sheets.vue
@@ -96,19 +96,33 @@
         // this.has_note = false    
       },
       deleteNote() {
-        var confirm = window.confirm(`Are you sure, you want to delete this note?`)
-        if (!confirm) return;
-
-        http
+        this.$confirm(`Are you sure you want to delete this note?`, 'Confirm Delete', {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          http
           .delete(`/projects/${this.currentProject.id}/facilities/${this.facility.id}/notes/${this.note.id}.json`)
           .then((res) => {
             this.loading = false
             this.$emit('note-deleted', this.note)
+            this.$message({
+              message: `Note was deleted successfully.`,
+              type: "success",
+              showClose: true,
+            });
           })
           .catch((err) => {
             this.loading = false
             console.error(err)
+            this.$message({
+              type: 'info',
+              message: 'Delete canceled',
+              showClose: true
+            });
           })
+          
+        });
       },
       downloadFile(file) {
         if (this._isallowed('write')) {

--- a/app/javascript/components/dashboard/notes/notes_show.vue
+++ b/app/javascript/components/dashboard/notes/notes_show.vue
@@ -85,19 +85,33 @@
         this.$emit('note-updated', note)
       },
       deleteNote() {
-        var confirm = window.confirm(`Are you sure, you want to delete this note?`)
-        if (!confirm) return;
-
-        http
+        this.$confirm(`Are you sure you want to delete this note?`, 'Confirm Delete', {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          http
           .delete(`/projects/${this.currentProject.id}/facilities/${this.facility.id}/notes/${this.note.id}.json`)
           .then((res) => {
             this.loading = false
             this.$emit('note-deleted', this.note)
+            this.$message({
+              message: `Note was deleted successfully.`,
+              type: "success",
+              showClose: true,
+            });
           })
           .catch((err) => {
             this.loading = false
             console.error(err)
+            this.$message({
+              type: 'info',
+              message: 'Delete canceled',
+              showClose: true
+            });
           })
+          
+        });
       },
       downloadFile(file) {
         if (this._isallowed('write')) {

--- a/app/javascript/components/dashboard/risks/risk_form.vue
+++ b/app/javascript/components/dashboard/risks/risk_form.vue
@@ -2088,14 +2088,28 @@ export default {
       this.DV_risk.riskFiles = _files;
     },
     deleteRisk() {
-      let confirm = window.confirm(
-        `Are you sure you want to delete this risk?`
-      );
-      if (!confirm) {
-        return;
-      }
-      this.riskDeleted(this.DV_risk);
-      this.cancelRiskSave();
+      this.$confirm(`Are you sure you want to delete ${this.DV_risk.text}?`, ` Confirm Delete`, {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          this.issueDeleted(this.DV_risk).then((value) => {
+            if (value === 'Success') {
+              this.$message({
+                message: `${this.DV_risk.text} was deleted successfully.`,
+                type: "success",
+                showClose: true,
+              });
+            }
+          });
+          this.cancelRiskSave();
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: 'Delete canceled',
+            showClose: true
+          });          
+      });
     },
     deleteFile(file) {
       if (!file) return;
@@ -2930,6 +2944,16 @@ export default {
     },
     "DV_risk.startDate"(value) {
       if (!value) this.DV_risk.dueDate = "";
+    },
+    "DV_risk.dueDate"(value) {
+      if (this.facility.dueDate) {
+        if (moment(value).isAfter(this.facility.dueDate, "day")) {
+          this.$alert(`${this.DV_risk.text} Due Date is past Project Due Date!`, `${this.DV_risk.text} Due Date Warning`, {
+          confirmButtonText: 'Ok',
+          type: 'info'
+        });
+        }
+      }
     },
     "DV_risk.checklists": {
       handler: function(value) {

--- a/app/javascript/components/dashboard/risks/sheets/risk_sheets.vue
+++ b/app/javascript/components/dashboard/risks/sheets/risk_sheets.vue
@@ -98,9 +98,27 @@
         'updateWatchedRisks'
       ]),
       deleteRisk() {
-        var confirm = window.confirm(`Are you sure, you want to delete "${this.DV_risk.text}"?`)
-        if (!confirm) {return}
-        this.riskDeleted(this.DV_risk)
+        this.$confirm(`Are you sure you want to delete ${this.DV_risk.text}?`, 'Confirm Delete', {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          this.riskDeleted(this.DV_risk).then((value) => {
+            if (value === 'Success') {
+              this.$message({
+                message: `${this.DV_risk.text} was deleted successfully.`,
+                type: "success",
+                showClose: true,
+              });
+            }
+          });
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: 'Delete canceled',
+            showClose: true
+          });          
+        });
       },  
       openSubRisk(subRisk) {
         let risk = this.currentRisks.find(t => t.id == subRisk.id)

--- a/app/javascript/components/dashboard/tasks/task_form.vue
+++ b/app/javascript/components/dashboard/tasks/task_form.vue
@@ -1289,14 +1289,28 @@ export default {
       //this.editTimeLive = moment.format('DD MMM YYYY, h:mm a')
     },
     deleteTask() {
-      let confirm = window.confirm(
-        `Are you sure you want to delete "${this.DV_task.text}"?`
-      );
-      if (!confirm) {
-        return;
-      }
-      this.taskDeleted(this.DV_task);
-      this.cancelSave();
+      this.$confirm(`Are you sure you want to delete ${this.DV_task.text}?`, 'Confirm Delete', {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          this.taskDeleted(this.DV_task).then((value) => {
+            if (value === 'Success') {
+              this.$message({
+                message: `${this.DV_task.text} was deleted successfully.`,
+                type: "success",
+                showClose: true,
+              });
+            }
+          });
+          this.cancelSave();
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: 'Delete canceled',
+            showClose: true
+          });          
+        });
     },
     progressListTitleText(progressList) {
       if (!progressList.id) return;
@@ -1893,7 +1907,10 @@ export default {
     "DV_task.dueDate"(value) {
       if (this._ismounted && this.facility.dueDate) {
         if (moment(value).isAfter(this.facility.dueDate, "day")) {
-          alert("Task Due Date is past Project Due Date!");
+          this.$alert(`${this.DV_task.text} Due Date is past Project Due Date!`, `${this.DV_task.text} Due Date Warning`, {
+          confirmButtonText: 'Ok',
+          type: 'info'
+        });
         }
       }
     },

--- a/app/javascript/components/dashboard/tasks/task_sheets.vue
+++ b/app/javascript/components/dashboard/tasks/task_sheets.vue
@@ -146,9 +146,27 @@ export default {
       this.$refs.menu.open(e);
     },
     deleteTask() {
-      let confirm = window.confirm(`Are you sure you want to delete "${this.DV_task.text}"?`)
-      if (!confirm) {return}
-      this.taskDeleted(this.DV_task)
+      this.$confirm(`Are you sure you want to delete ${this.DV_task.text}?`, 'Confirm Delete', {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          this.taskDeleted(this.DV_task).then((value) => {
+            if (value === 'Success') {
+              this.$message({
+                message: `${this.DV_task.text} was deleted successfully.`,
+                type: "success",
+                showClose: true,
+              });
+            }
+          });
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: 'Delete canceled',
+            showClose: true
+          });          
+        });
     }
   },
   computed: {

--- a/app/javascript/components/dashboard/tasks/task_show.vue
+++ b/app/javascript/components/dashboard/tasks/task_show.vue
@@ -130,9 +130,27 @@
         'updateWatchedTasks'
       ]),
       deleteTask() {
-        let confirm = window.confirm(`Are you sure, you want to delete "${this.DV_task.text}"?`)
-        if (!confirm) {return}
-        this.taskDeleted(this.DV_task)
+        this.$confirm(`Are you sure you want to delete ${this.DV_task.text}?`, 'Confirm Delete', {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          this.taskDeleted(this.DV_task).then((value) => {
+            if (value === 'Success') {
+              this.$message({
+                message: `${this.DV_task.text} was deleted successfully.`,
+                type: "success",
+                showClose: true,
+              });
+            }
+          });
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: 'Delete canceled',
+            showClose: true
+          });          
+        });
       },
       openSubTask(subTask) {
         let task = this.currentTasks.find(t => t.id == subTask.id)

--- a/app/javascript/components/views/lessons/LessonForm.vue
+++ b/app/javascript/components/views/lessons/LessonForm.vue
@@ -709,10 +709,28 @@
         this.currentTab = tab ? tab.key : 'tab1'
       },
       deleteTask() {
-        let confirm = window.confirm(`Are you sure you want to delete "${this.DV_lesson.title}"?`)
-        if (!confirm) {return}
-        this.taskDeleted(this.DV_lesson)
-        this.cancelSave()
+        this.$confirm(`Are you sure you want to delete ${this.DV_lesson.text}?`, 'Confirm Delete', {
+          confirmButtonText: 'Delete',
+          cancelButtonText: 'Cancel',
+          type: 'warning'
+        }).then(() => {
+          this.taskDeleted(this.DV_lesson).then((value) => {
+            if (value === 'Success') {
+              this.$message({
+                message: `${this.DV_lesson.text} was deleted successfully.`,
+                type: "success",
+                showClose: true,
+              });
+            }
+          });
+          this.cancelSave();
+        }).catch(() => {
+          this.$message({
+            type: 'info',
+            message: 'Delete canceled',
+            showClose: true
+          });          
+        });
       },
       progressListTitleText(progressList){
         if(!progressList.id) return;

--- a/app/javascript/components/views/lessons/LessonsIndex.vue
+++ b/app/javascript/components/views/lessons/LessonsIndex.vue
@@ -276,7 +276,11 @@ export default {
       if (this.currentPage > 1) this.currentPage--;
     },
     clear: function() {
-      alert('this button works')
+      this.$alert('this button works',
+      {
+        confirmButtonText: 'OK',
+        type:'info'      
+      });
       // document.getElementsByClassName("searchbox").empty();
     },
     memberSearch() {

--- a/app/javascript/routers/dashboard.js
+++ b/app/javascript/routers/dashboard.js
@@ -159,7 +159,11 @@ export default new VueRouter({
             }
 
             if( fPrivilege["overview"].hide && fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide && fPrivilege["notes"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             if( !fPrivilege["overview"].hide ){
               next()  
@@ -192,7 +196,11 @@ export default new VueRouter({
               return
             }
             if( fPrivilege["overview"].hide && fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide && fPrivilege["notes"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             if( !fPrivilege["tasks"].hide ){
               next()  
@@ -225,7 +233,11 @@ export default new VueRouter({
               return
             }
             if( fPrivilege["overview"].hide && fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide && fPrivilege["notes"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             if( !fPrivilege["tasks"].hide ){
               next()  
@@ -258,7 +270,11 @@ export default new VueRouter({
               return
             }
             if( fPrivilege["overview"].hide && fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide && fPrivilege["notes"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             if( !fPrivilege["issues"].hide ){
               next()  
@@ -291,7 +307,11 @@ export default new VueRouter({
               return
             }
             if( fPrivilege["overview"].hide && fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide && fPrivilege["notes"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             if( !fPrivilege["issues"].hide ){
               next()  
@@ -324,7 +344,11 @@ export default new VueRouter({
               return
             }
             if( fPrivilege["overview"].hide && fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide && fPrivilege["notes"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             if( !fPrivilege["risks"].hide ){
               next()  
@@ -357,7 +381,11 @@ export default new VueRouter({
               return
             }
             if( fPrivilege["overview"].hide && fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide && fPrivilege["notes"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             if( !fPrivilege["risks"].hide ){
               next()  
@@ -390,7 +418,11 @@ export default new VueRouter({
               return
             }
             if( fPrivilege["overview"].hide && fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide && fPrivilege["notes"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             if( !fPrivilege["notes"].hide ){
               next()  
@@ -423,7 +455,11 @@ export default new VueRouter({
               return
             }
             if( fPrivilege["overview"].hide && fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide && fPrivilege["notes"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             if( !fPrivilege["notes"].hide ){
               next()  
@@ -523,7 +559,11 @@ export default new VueRouter({
             }
 
             if( fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             
             if( !fPrivilege["tasks"].hide ){
@@ -554,7 +594,11 @@ export default new VueRouter({
             }
 
             if( fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             
             if( !fPrivilege["tasks"].hide ){
@@ -584,7 +628,11 @@ export default new VueRouter({
             }
 
             if( fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             
             if( !fPrivilege["issues"].hide ){
@@ -615,7 +663,11 @@ export default new VueRouter({
             }
 
             if( fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             
             if( !fPrivilege["issues"].hide ){
@@ -645,7 +697,11 @@ export default new VueRouter({
             }
 
             if( fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             
             if( !fPrivilege["risks"].hide ){
@@ -676,7 +732,11 @@ export default new VueRouter({
             }
 
             if( fPrivilege["tasks"].hide && fPrivilege["issues"].hide && fPrivilege["risks"].hide){
-              alert("You don't have access to see any tabs. Please contact administrator")
+              this.$alert('You do not have access to see any tabs. Please contact an administrator',
+                {
+                  confirmButtonText: 'OK',
+                  type:'info'      
+                });
             }
             
             if( !fPrivilege["risks"].hide ){

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,9 +21,9 @@ ActiveRecord::Schema.define(version: 2021_05_12_220200) do
     t.bigint "author_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
-    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource"
   end
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
@@ -260,15 +260,6 @@ ActiveRecord::Schema.define(version: 2021_05_12_220200) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "lesson_stage_id"
-    t.integer "facility_project_id"
-    t.index ["facility_project_id"], name: "index_lessons_on_facility_project_id"
-    t.index ["issue_id"], name: "index_lessons_on_issue_id"
-    t.index ["issue_type_id"], name: "index_lessons_on_issue_type_id"
-    t.index ["lesson_stage_id"], name: "index_lessons_on_lesson_stage_id"
-    t.index ["risk_id"], name: "index_lessons_on_risk_id"
-    t.index ["task_id"], name: "index_lessons_on_task_id"
-    t.index ["task_type_id"], name: "index_lessons_on_task_type_id"
-    t.index ["user_id"], name: "index_lessons_on_user_id"
   end
 
   create_table "notes", charset: "utf8", force: :cascade do |t|
@@ -441,7 +432,7 @@ ActiveRecord::Schema.define(version: 2021_05_12_220200) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["target_type", "target_id", "var"], name: "index_rails_settings_on_target_type_and_target_id_and_var", unique: true
-    t.index ["target_type", "target_id"], name: "index_rails_settings_on_target_type_and_target_id"
+    t.index ["target_type", "target_id"], name: "index_rails_settings_on_target"
   end
 
   create_table "region_states", charset: "utf8", force: :cascade do |t|
@@ -486,17 +477,6 @@ ActiveRecord::Schema.define(version: 2021_05_12_220200) do
     t.index ["task_id"], name: "index_related_tasks_on_task_id"
   end
 
-  create_table "resource_access_requests", charset: "utf8", force: :cascade do |t|
-    t.integer "resource_id", null: false
-    t.string "resource_type", null: false
-    t.integer "user_id", null: false
-    t.string "status", default: "pending"
-    t.integer "granted_by_id", null: false
-    t.string "permissions"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "risk_stages", charset: "utf8", force: :cascade do |t|
     t.string "name"
     t.integer "percentage", default: 0
@@ -534,7 +514,6 @@ ActiveRecord::Schema.define(version: 2021_05_12_220200) do
     t.datetime "updated_at", null: false
     t.bigint "task_type_id"
     t.string "text"
-    t.bigint "risk_id"
     t.integer "kanban_order", default: 0
     t.bigint "risk_stage_id"
     t.string "probability_name"
@@ -544,7 +523,6 @@ ActiveRecord::Schema.define(version: 2021_05_12_220200) do
     t.boolean "approved"
     t.index ["due_date"], name: "index_risks_on_due_date"
     t.index ["facility_project_id"], name: "index_risks_on_facility_project_id"
-    t.index ["risk_id"], name: "index_risks_on_risk_id"
     t.index ["risk_stage_id"], name: "index_risks_on_risk_stage_id"
     t.index ["task_type_id"], name: "index_risks_on_task_type_id"
     t.index ["user_id"], name: "index_risks_on_user_id"


### PR DESCRIPTION
Events changed from browser alerts to ElementUI popUps: 
task_form that says Task due date is later than Project due date when such happens DV_task.DueDate, 
members_view.vue: clear: function(), LessonsIndex: clear: function(), 
dashboardjs alerts (this.$alert) when user doesn't have permissions to see tabs, 
deletions (issue_sheets.vue:deleteIssue(), issue_show.vue:deleteIssue(), 
	notes_form.vue:deleteNote(), notes_sheets.vue:deleteNote(), note_show.vue:deleteNote(), 
	risk_sheets.vue:deleteRisk(), 
	task_sheets.vue:deleteTask(), task_show.vue:deleteTask(), 
	LessonForm.vue:deleteTask() ),
issue_form.vue:DV_issue.DueDate, 
risk_form.vue:DV_risk.DueDate