### PR TITLE
2263 - Favorites selector placeholder

### DIFF
--- a/app/javascript/components/shared/filter_sidebar.vue
+++ b/app/javascript/components/shared/filter_sidebar.vue
@@ -387,7 +387,7 @@
                   track-by="name" 
                   filterable
                   value-key="id"
-                  placeholder="Search and select Project Group"
+                  placeholder="Search and select Favorites"
                 >
                   <el-option 
                     v-for="item in C_favoriteFilterSelectOptions"                                                     


### PR DESCRIPTION
Issue  #2263 - Select Favorites filter placeholder text should not be "Search and select Project Group"