### PR TITLE
Automatically delete empty updates, successes, failures, and best practices.

### DIFF
--- a/app/javascript/components/dashboard/lessons/LessonForm.vue
+++ b/app/javascript/components/dashboard/lessons/LessonForm.vue
@@ -856,6 +856,11 @@ export default {
         if (!success) {
           return;
         }
+        //removes empty updates, sucesses, failures, and best practices
+        this.removeEmptyUpdates()
+        this.removeEmptySFBP(this.successes, this.deleteSuccesses)
+        this.removeEmptySFBP(this.failures, this.deleteFailures)
+        this.removeEmptySFBP(this.bestPractices, this.deleteBestPractices)
 
         let lessonData = {
           lesson: {
@@ -898,6 +903,25 @@ export default {
           });
         }
       });
+    },
+    removeEmptyUpdates(){
+      for (let i in this.updates) {
+        if(!this.updates[i].body && !this.updates[i]._destroy) {
+          this.updates[i]._destroy = true;
+          this.deleteUpdates.push(this.updates[i]);
+          this.updates.splice(i, 1);
+        }
+      }
+    },
+    removeEmptySFBP(sFBP, deleteSFBP){
+      for (let i in sFBP) {
+        //if(this.lesson.draft && sFBP[i].recommendation) continue;
+        if(!sFBP[i].finding && !sFBP[i]._destroy && !(this.lesson.draft && sFBP[i].recommendation)) {
+          sFBP[i]._destroy = true;
+          deleteSFBP.push(sFBP[i]);
+          sFBP.splice(i, 1);
+        }
+      }
     },
     _isallowed(salut) {
         var programId = this.$route.params.programId;

--- a/app/javascript/components/dashboard/lessons/LessonForm.vue
+++ b/app/javascript/components/dashboard/lessons/LessonForm.vue
@@ -915,7 +915,6 @@ export default {
     },
     removeEmptySFBP(sFBP, deleteSFBP){
       for (let i in sFBP) {
-        //if(this.lesson.draft && sFBP[i].recommendation) continue;
         if(!sFBP[i].finding && !sFBP[i]._destroy && !(this.lesson.draft && sFBP[i].recommendation)) {
           sFBP[i]._destroy = true;
           deleteSFBP.push(sFBP[i]);


### PR DESCRIPTION
Issue #3028 

For successes, failures, and best practices
It will delete items that have an empty Finding, however, if the form is selected as a draft, it will save that item if it has a Recommended but no Finding.