### PR TITLE
LessonDetails: detail type filter should not be preselected

### DIFF
--- a/app/admin/lesson_details.rb
+++ b/app/admin/lesson_details.rb
@@ -72,5 +72,5 @@ ActiveAdmin.register LessonDetail do
   filter :recommendation
   filter :created_at
   filter :updated_at
-  filter :detail_type, as: :select, collection: -> {[["Success","success"], ["Failure", "failure"], ["Best Practices", "best_practices"]]}, include_blank: false
+  filter :detail_type, as: :select, collection: -> {[["Success","success"], ["Failure", "failure"], ["Best Practices", "best_practices"]]}
 end


### PR DESCRIPTION
Resolves #3046, #3047 and #3048
Before: 
![Screenshot 2021-07-13 at 8 22 40 AM](https://user-images.githubusercontent.com/86612095/125479166-1d699d34-033e-42f3-bb65-4cd573b2de5a.png)
After:
![Screenshot 2021-07-13 at 8 20 43 AM](https://user-images.githubusercontent.com/86612095/125479197-d4c1d31f-9d6f-4bf6-b072-718ad7a845db.png)
![Screenshot 2021-07-13 at 8 20 58 AM](https://user-images.githubusercontent.com/86612095/125479234-95c21243-31ed-43dc-a8aa-41970cde168f.png)
