### PR TITLE
2518 - Progress bar not display Adv Filters

### DIFF
--- a/app/javascript/components/shared/filter_sidebar.vue
+++ b/app/javascript/components/shared/filter_sidebar.vue
@@ -1538,7 +1538,7 @@ export default {
 <style scoped lang="scss">
 #filterbar {
   position: absolute;
-  z-index: 1000;
+  z-index: 1100;
   transition: .4s ease;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.19), 0 24px 24px rgba(0, 0, 0, 0.23);
 }


### PR DESCRIPTION
Fixes Issue #2518 - Progress % circle indicator on action forms should not display on Advanced Filters