### PR TITLE
Sort '---' category for no category

### DIFF
--- a/app/javascript/components/views/portfolio/PortfolioView.vue
+++ b/app/javascript/components/views/portfolio/PortfolioView.vue
@@ -1795,6 +1795,8 @@ export default {
           return this.tasksObj.sort((a,b) => {
           let modifier = 1;
           if(this.currentSortDir === 'desc') modifier = -1;
+          if (a.category === null && this.currentSort === 'category') return 1;
+          if (b.category === null && this.currentSort === 'category') return -1;
           if(a[this.currentSort] < b[this.currentSort]) return -1 * modifier;
           if(a[this.currentSort] > b[this.currentSort]) return 1 * modifier;
           return 0;
@@ -1809,6 +1811,8 @@ export default {
           return this.issuesObj.sort((a,b) => {
           let modifier = 1;
           if(this.currentSortDir === 'desc') modifier = -1;
+          if (a.category === null && this.currentSort === 'category') return 1;
+          if (b.category === null && this.currentSort === 'category') return -1;
           if(a[this.currentSort] < b[this.currentSort]) return -1 * modifier;
           if(a[this.currentSort] > b[this.currentSort]) return 1 * modifier;
           return 0;
@@ -1823,6 +1827,8 @@ export default {
           return this.risksObj.sort((a,b) => {
           let modifier = 1;
           if(this.currentSortDir === 'desc') modifier = -1;
+          if (a.category === null && this.currentSort === 'category') return 1;
+          if (b.category === null && this.currentSort === 'category') return -1;
           if(a[this.currentSort] < b[this.currentSort]) return -1 * modifier;
           if(a[this.currentSort] > b[this.currentSort]) return 1 * modifier;
           return 0;
@@ -1837,6 +1843,8 @@ export default {
           return this.lessonsObj.sort((a,b) => {
           let modifier = 1;
           if(this.currentSortDir === 'desc') modifier = -1;
+          if (a.category === null && this.currentSort === 'category') return 1;
+          if (b.category === null && this.currentSort === 'category') return -1;
           if(a[this.currentSort] < b[this.currentSort]) return -1 * modifier;
           if(a[this.currentSort] > b[this.currentSort]) return 1 * modifier;
           return 0;


### PR DESCRIPTION
Resolves #3241 
Before:
![Screenshot 2021-08-06 at 3 46 20 PM](https://user-images.githubusercontent.com/86612095/128563778-ea4e28fb-cb89-44a6-ae79-bd75e389c11d.png)
After:
![Screenshot 2021-08-06 at 3 44 43 PM](https://user-images.githubusercontent.com/86612095/128563753-8a52c93a-a97c-4146-8051-78e7ef3f15b0.png)
