### PR TITLE
1521 risk filter priority level

### DIFF
--- a/app/controllers/api/v1/filter_data_controller.rb
+++ b/app/controllers/api/v1/filter_data_controller.rb
@@ -105,11 +105,11 @@ class Api::V1::FilterDataController < AuthenticatedController
 
   def risk_priority_level
     risk_priority_levels = [
-      {id: 1, value: 1, name: "Very Low"},
-      {id: 2, value: 2, name: "Low"},
-      {id: 3, value: 3, name: "Moderate"},
-      {id: 4, value: 4, name: "High"},
-      {id: 5, value: 5, name: "Extreme"}
+      {id: 'very low', value: 'very low', name: 'Very Low 1'},
+      {id: 'low', value: 'low', name: 'Low 2 - 3'},
+      {id: 'moderate', value: 'moderate', name: 'Moderate 4 - 6'},
+      {id: 'high', value: 'high', name: 'High 8 - 12'},
+      {id: 'extreme', value: 'extreme', name: 'Extreme 15 - 25'}
     ]
     render json: {risk_priorities: risk_priority_levels}
   end

--- a/app/javascript/components/views/portfolio/PortfolioView.vue
+++ b/app/javascript/components/views/portfolio/PortfolioView.vue
@@ -4681,8 +4681,8 @@ export default {
         })
         .filter((risk) => {
           if (this.C_riskPriorityLevelFilter.length > 0) {
-            let priority = this.C_riskPriorityLevelFilter.map((t) => t.name);
-            return priority.includes(risk.priority_level);
+            let priority = this.C_riskPriorityLevelFilter.map((t) => t.id);
+            return priority.includes(risk.priority_level.toLowerCase());
           } else return true;
         })
         .filter((risk) => {

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -596,7 +596,8 @@ export default new Vuex.Store({
     getRiskPriorityLevelFilter: state => state.riskPriorityLevelFilter,
     getRiskPriorityLevelFilterOptions: (state, getters) => {
       var options = [
-        {id: 'low', name: 'Low 1 - 3', value: 'low'},
+        {id: 'very low', name: 'Very Low 1', value: 'very low'},
+        {id: 'low', name: 'Low 2 - 3', value: 'low'},
         {id: 'moderate', name: 'Moderate 4 - 6', value: 'moderate'},
         {id: 'high', name: 'High 8 - 12', value: 'high' },
         {id: 'extreme', name: 'Extreme 15 - 25', value: 'extreme'}


### PR DESCRIPTION
- Add `Very low 1` risk priority filter option
- Update Portfolio Advanced filters - risk priority level filter meaningful options
- Update Portfolio risk priority level filter function according to the above modification

Resolved #1521 
![Screenshot 2021-09-02 at 2 50 53 PM](https://user-images.githubusercontent.com/86612095/131900112-318e926c-9157-451d-8361-68b141fa4213.png)
