### PR TITLE
[3783] Left sidebar menu: Should display full Group Name on hover

### DIFF
--- a/app/javascript/components/shared/ProjectSidebar.vue
+++ b/app/javascript/components/shared/ProjectSidebar.vue
@@ -33,7 +33,7 @@
             <span v-show="expanded.id == group.id">
               <i class="fa fa-angle-down font-md mr-2 clickable"></i>
             </span>
-           <p class="clickable groupName">{{ group.name }}</p>
+           <p class="clickable groupName" v-tooltip="group.name">{{ group.name }}</p>
            </span>
          </div>
 

--- a/app/javascript/components/shared/ProjectSidebar.vue
+++ b/app/javascript/components/shared/ProjectSidebar.vue
@@ -33,7 +33,7 @@
             <span v-show="expanded.id == group.id">
               <i class="fa fa-angle-down font-md mr-2 clickable"></i>
             </span>
-           <p class="clickable groupName" v-tooltip="group.name">{{ group.name }}</p>
+           <p class="clickable groupName expandText">{{ group.name }}</p>
            </span>
          </div>
 
@@ -367,6 +367,17 @@ export default {
       color: unset;
       text-decoration: unset;
     }
+  }
+  .expandText {
+    text-overflow: ellipsis;
+    overflow : hidden;
+    white-space: nowrap;
+  }
+
+  .expandText:hover {
+    text-overflow: clip;
+    white-space: normal;
+    word-break: break-all;
   }
 }
 </style>


### PR DESCRIPTION
Resolves #3783 
**on hover, it expands the text when ellipsis**

older:
![Screenshot 2022-01-06 at 1 09 04 PM](https://user-images.githubusercontent.com/86612095/148430074-94bcd2e2-db73-4066-80f5-431d61ce312c.png)
New:
![Screenshot 2022-01-11 at 9 05 51 AM](https://user-images.githubusercontent.com/86612095/148957436-1cfe2b20-b774-477b-99ba-56cf2d422663.png)

