### PR TITLE
Fix for issue 3937

### DIFF
--- a/app/javascript/components/shared/ProjectRollup.vue
+++ b/app/javascript/components/shared/ProjectRollup.vue
@@ -17,7 +17,7 @@
             >{{ currentProject.facilities.length }}
             </span>
         </el-button>
-        <el-button :class="[ getShowProjectStats ? 'lightBtn' : 'inactive']" @click.prevent="showContractStats" class="pr-2"> 
+        <el-button :class="[ getShowProjectStats ? 'lightBtn' : 'inactive']" @click.prevent="showContractStats" class="pr-2" v-show="isSheetsView"> 
           <!-- <i class="far fa-file-contract mr-1" :class="[ getShowProjectStats == false ? 'inactive' : 'mh-orange-text']"></i> -->
           CONTRACTS 
             <span 

--- a/app/javascript/components/shared/ProjectSidebar.vue
+++ b/app/javascript/components/shared/ProjectSidebar.vue
@@ -266,10 +266,10 @@ export default {
   watch: {
     contentLoaded: {
       handler() {
-        if (this.currentFacility && !this.$route.params.contractId ){             
-          this.SET_EXPANDED_GROUP(this.currentFacility.facility.facilityGroupId)
+        if (this.currentFacility && !this.$route.params.contractId && this.currentFacilityGroup ){             
+          this.SET_EXPANDED_GROUP(this.currentFacilityGroup.id)
         }
-         if (this.currentContract && !this.$route.params.projectId) {
+         if (this.currentContract && !this.$route.params.projectId && this.currentContract.facilityGroupId) {
           this.SET_EXPANDED_GROUP(this.currentContract.facilityGroupId)
         }
         // Expand the project tree if there is only one project group on refresh

--- a/app/javascript/components/views/map/MapView.vue
+++ b/app/javascript/components/views/map/MapView.vue
@@ -83,7 +83,7 @@
         "
         class="d-flex align-items-center my-2"
       >
-        <i class="fal fa-clipboard-list mh-green-text"></i>
+        <i class="fal fa-clipboard-list mh-green-text pr-2"></i>
         <h5 class="f-head mb-0">{{ currentFacility.facilityName }}</h5>
       </div>
       <ProjectTabs
@@ -154,6 +154,7 @@ export default {
       "currentProject",
       "filterFacilitiesWithActiveFacilityGroups",
       "filteredFacilities",
+      "getShowProjectStats",
       "getMapZoomFilter",
       "getUnfilteredFacilities",
       "getNewSession",
@@ -184,6 +185,7 @@ export default {
       "setCurrentFacility",
       "setMapZoomFilter",
       "setFacilities",
+      'setShowProjectStats',
       "setPreviousRoute",
       "setNewSession",
     ]),
@@ -306,6 +308,10 @@ export default {
   },
   mounted() {
     // Display notification if the Map Boundary Filter is still on
+    if(this.getShowProjectStats){
+     this.setShowProjectStats(!this.getShowProjectStats)
+    }
+
     if (this.facilities.length !== this.getUnfilteredFacilities.length) {
       this.$notify.info({
         title: "Filter Set",

--- a/app/javascript/components/views/program/ProgramProjectsSheet.vue
+++ b/app/javascript/components/views/program/ProgramProjectsSheet.vue
@@ -271,7 +271,10 @@ export default {
     ...mapActions(["fetchFacilities", "fetchCurrentProject"]),
     ...mapMutations(["setProjectGroupFilter", "setGroupFilter"]),
     goToProject(index, rows) {  
-      window.location.pathname = `/programs/${this.programId}/sheet/projects/${rows.id}/`
+      if(this.isMapView){
+        window.location.pathname = `/programs/${this.programId}/map/projects/${rows.id}/`
+      } else  window.location.pathname = `/programs/${this.programId}/sheet/projects/${rows.id}/`
+     
       // router.push more efficient but programPrivileges errors persist unless reload
       // this.$router.push({
       //   name: "SheetProject",
@@ -365,6 +368,9 @@ export default {
       "facilityGroupFacilities",
       "filteredFacilityGroups",
     ]),
+    isMapView() {
+      return this.$route.name.includes("Map");
+    },
     // Filter for Projects Table
     C_groupFilter: {
       get() {


### PR DESCRIPTION
Issue #3937 :  Map View doesn't support contracts, therefore, contract tab was removed.  In Sheet View or Map View, clicking on Projects table button "Go to Project" now directs you to current view.