### PR TITLE
Modified portfolio fetch responses to return data with action url forms only.

### DIFF
--- a/app/javascript/components/views/portfolio/PortfolioIssueForm.vue
+++ b/app/javascript/components/views/portfolio/PortfolioIssueForm.vue
@@ -12,13 +12,7 @@ export default {
   },
   methods:{
     ...mapActions([
-      'fetchPortfolioIssue', 
-      'fetchPortfolioIssues', 
-      'fetchPortfolioAssignees', 
-      'fetchPortfolioIssueStages', 
-      'fetchPortfolioIssueTypes', 
-      'fetchPortfolioIssueSeverities',
-      'fetchPortfolioCategories',
+      'fetchPortfolioIssue',      
       ]),
     redirectBack() {
       this.$router.push(
@@ -27,15 +21,10 @@ export default {
     },
   },
   computed: {
-    ...mapGetters(['portfolioIssue', 'portfolioTab'])
+    ...mapGetters(['portfolioIssue'])
   },
   mounted(){
-    this.fetchPortfolioCategories()
     this.fetchPortfolioIssue(this.$route.params)
-    this.fetchPortfolioIssueStages()
-    this.fetchPortfolioAssignees()
-    this.fetchPortfolioIssueTypes()
-    this.fetchPortfolioIssueSeverities()
   },
 };
 </script>

--- a/app/javascript/components/views/portfolio/PortfolioRiskForm.vue
+++ b/app/javascript/components/views/portfolio/PortfolioRiskForm.vue
@@ -12,7 +12,7 @@ export default {
     portfolioRiskForm,
   },
   methods:{
-    ...mapActions(['fetchPortfolioRisk', 'fetchPortfolioCategories', 'fetchPortfolioAssignees', 'fetchPortfolioRiskStages' ]),
+    ...mapActions(['fetchPortfolioRisk']),
     redirectBack() {
       this.$router.push(
         `/portfolio`
@@ -23,10 +23,7 @@ export default {
     ...mapGetters(['portfolioRisk'])
   },
   mounted(){
-    this.fetchPortfolioCategories()
     this.fetchPortfolioRisk(this.$route.params)
-    this.fetchPortfolioAssignees()
-    this.fetchPortfolioRiskStages() 
   },
 };
 </script>

--- a/app/javascript/components/views/portfolio/PortfolioTaskForm.vue
+++ b/app/javascript/components/views/portfolio/PortfolioTaskForm.vue
@@ -13,7 +13,7 @@ export default {
     portfolioTaskForm,
   },
   methods:{
-    ...mapActions(['fetchPortfolioTask', 'portfolioTaskLoaded', 'fetchPortfolioAssignees', 'fetchPortfolioTasks', 'fetchPortfolioCategories', 'fetchPortfolioTaskStages']),
+    ...mapActions(['fetchPortfolioTask']),
     redirectBack() {
       this.$router.push(
         `/portfolio`
@@ -23,11 +23,8 @@ export default {
   computed: {
     ...mapGetters(['portfolioTask'])
   },
- mounted(){
-    this.fetchPortfolioCategories()
-    this.fetchPortfolioTask(this.$route.params)
-    this.fetchPortfolioAssignees()
-    this.fetchPortfolioTaskStages()
+ mounted(){   
+    this.fetchPortfolioTask(this.$route.params)   
   },
 };
 </script>

--- a/app/javascript/components/views/portfolio/portfolio_issue_form.vue
+++ b/app/javascript/components/views/portfolio/portfolio_issue_form.vue
@@ -1380,6 +1380,7 @@ export default {
     AuthorizationService.getRolePrivileges();
     this.fetchPortfolioIssue(this.$route.params)
     this.fetchPortfolioIssueStages()
+    this.fetchPortfolioCategories()
     this.fetchPortfolioAssignees()
     this.fetchPortfolioIssueTypes()
     this.fetchPortfolioIssueSeverities()
@@ -1399,6 +1400,7 @@ export default {
       "taskUpdated", 
       "updateWatchedIssues", 
       'fetchPortfolioIssue',
+      "fetchPortfolioCategories",
       "fetchPortfolioIssueStages",
       "fetchPortfolioAssignees",
       "fetchPortfolioIssueTypes",
@@ -1512,7 +1514,6 @@ export default {
     },
     loadIssue(issue) {
       this.DV_issue = { ...this.DV_issue, ..._.cloneDeep(issue) };
-
       this.responsibleUsers = _.filter(this.activeProjectUsers, (u) =>
         this.DV_issue.responsible_user_ids.includes(u.id)
       )[0];
@@ -1525,7 +1526,6 @@ export default {
       this.informedIssueUsers = _.filter(this.activeProjectUsers, (u) =>
         this.DV_issue.informed_user_ids.includes(u.id)
       );
-
       this.relatedIssues = _.filter(this.currentIssues, (u) =>
         this.DV_issue.sub_issue_ids.includes(u.id)
       );

--- a/app/javascript/components/views/portfolio/portfolio_risk_form.vue
+++ b/app/javascript/components/views/portfolio/portfolio_risk_form.vue
@@ -2151,15 +2151,22 @@ export default {
     if (this.fixedStage) {
       this.selectedRiskStage = this.fixedStage;
     }
-  },
+  }, 
   mounted() {
-    AuthorizationService.getRolePrivileges();
+    // this.fetchPortfolioAssignees()
+    this.fetchPortfolioRiskStages()
+    this.fetchPortfolioAssignees()
+    this.fetchPortfolioCategories()
+    console.log(this.$route.params)
+    AuthorizationService.getRolePrivileges();       
     if (!_.isEmpty(this.risk)) {
       this.loadRisk(this.risk);
     } else {
       this.loading = false;
       this.loadRisk(this.DV_risk);
-    }
+    }   
+    this.loading = false;
+    this._ismounted = true; 
   },
   methods: {
     ...mapMutations([
@@ -2176,6 +2183,10 @@ export default {
       "riskUpdated",
       "updateWatchedRisks",
       "updateApprovedRisks",
+      'fetchPortfolioAssignees', 
+      'fetchPortfolioCategories', 
+      'fetchPortfolioRiskStages',
+      'fetchPortfolioRisk'
     ]),
     INITIAL_RISK_STATE() {
       return {
@@ -2961,10 +2972,10 @@ export default {
   computed: {
     ...mapGetters([
       "portfolioRisks",
+      "portfolioRisk",
       "portfolioUsers",
       "currentIssues",
       "portfolioCategories", 
-      'fetchPortfolioRisks',
       'portfolioRiskLoaded',
       "categories",
       "currentProject",
@@ -2989,12 +3000,12 @@ export default {
       'riskDispositionDuration',
       "portfolioRiskStages",
      ]),
-  riskStages(){
+     riskStages(){
           if(this.portfolioRiskStages){
             return this.portfolioRiskStages.program_stages
           }
        },
-  riskStagesSorted() { 
+    riskStagesSorted() { 
       if (this.riskStages) {
         let stageObj =  [...this.riskStages[this.programId]]
         return stageObj.sort((a,b) => (a.percentage > b.percentage) ? 1 : -1);  
@@ -3025,7 +3036,7 @@ export default {
         return _.map(this.riskStages[this.programId], "percentage").toString();
      }    
     },
-  taskTypes(){
+    taskTypes(){
       return this.portfolioCategories  
     },
     isMapView() {

--- a/app/javascript/components/views/portfolio/portfolio_task_form.vue
+++ b/app/javascript/components/views/portfolio/portfolio_task_form.vue
@@ -1355,6 +1355,9 @@ export default {
   },
   mounted() {
    AuthorizationService.getRolePrivileges();
+   this.fetchPortfolioTaskStages();
+   this.fetchPortfolioCategories();
+   this.fetchPortfolioAssignees();
     if (!_.isEmpty(this.task)) {
       this.loadTask(this.task);
     } else {
@@ -1366,7 +1369,15 @@ export default {
   },
   methods: {
     ...mapMutations(["setTaskForManager", "updateTasksHash", 'setPortfolioCategoriesFilter']),
-    ...mapActions(["taskDeleted", "taskUpdated", "updateWatchedTasks", 'fetchPortfolioTask']),
+    ...mapActions([
+      "taskDeleted", 
+      "taskUpdated", 
+      "updateWatchedTasks", 
+      'fetchPortfolioTask', 
+      'fetchPortfolioTaskStages', 
+      'fetchPortfolioCategories',
+      'fetchPortfolioAssignees'
+    ]),
     INITIAL_TASK_STATE() {
       return {
         text: "",


### PR DESCRIPTION
Prior to this update, form data was populated by data dependent on row click.  Recent use case calls for form data to be readily available using only the form url (ie, programId, projectID, and taskID, https://mpath-dev.microhealthllc.com/portfolio/program/1/project/46/task/43...info that is normally fetched when user clicks row.)  This update fetches form data based on url.  